### PR TITLE
Fix vs30_class name in CY14 docs

### DIFF
--- a/R/CY14.R
+++ b/R/CY14.R
@@ -22,7 +22,7 @@
 #' @param regionflag 0 Global, 1 Japan and Italy, 2 Wenchuan (note only for M7.9)
 #'
 #' @return A list will be return, including mag, Rrup, Rjb, specT, period, lnY, sigma, iflag, Vs30,
-#' dip, Ztor, ftype, Z10, vs3-_class, hwflag, Rx, regionflag, phi, tau.
+#' dip, Ztor, ftype, Z10, vs30_class, hwflag, Rx, regionflag, phi, tau.
 #'
 #' @examples
 #' CY14(6, 20, 20, 0, 760, 90, 0, 0, 0.5, 1, 0, 20, 0)

--- a/man/CY14.Rd
+++ b/man/CY14.Rd
@@ -36,7 +36,7 @@ CY14(Mag, Rrup, Rjb, Prd, Vs30, Dip, Ztor, ftype = 0, Z1.0,
 }
 \value{
 A list will be return, including mag, Rrup, Rjb, specT, period, lnY, sigma, iflag, Vs30,
-dip, Ztor, ftype, Z10, vs3-_class, hwflag, Rx, regionflag, phi, tau.
+dip, Ztor, ftype, Z10, vs30_class, hwflag, Rx, regionflag, phi, tau.
 }
 \description{
 \code{CY14} returns the ground-motion prediction with it sigma of Chiou and Youngs(2014) GMPE.


### PR DESCRIPTION
## Summary
- correct documentation for `CY14` return value in R and Rd files

## Testing
- `Rscript -e 'devtools::test()'`

------
https://chatgpt.com/codex/tasks/task_e_684a1f2cf2b0833385c458a5a0cab9d2